### PR TITLE
Fixed the table crtsh_certificate to populate the public_key column value correctly and increase the connection timeout for the crt.sh public postgres database

### DIFF
--- a/crtsh/utils.go
+++ b/crtsh/utils.go
@@ -61,6 +61,9 @@ func serialNumberToHex(_ context.Context, d *transform.TransformData) (interface
 }
 
 func publicKeyToPem(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	if d.Value == nil {
+		return nil, nil
+	}
 	var result interface{}
 	switch d.Value.(type) {
 	case *ecdsa.PublicKey:
@@ -121,7 +124,7 @@ func connect(ctx context.Context, d *plugin.QueryData) (*sqlx.DB, error) {
 		}
 	}
 
-	connString := "postgres://guest@crt.sh:5432/certwatch?binary_parameters=yes"
+	connString := "postgres://guest@crt.sh:5432/certwatch?binary_parameters=yes&connect_timeout=60"
 	db, err := sqlx.Connect("postgres", connString)
 	if err != nil {
 		plugin.Logger(ctx).Error("crtsh_ca_issuer.listCaIssuer", "connection_error", err)


### PR DESCRIPTION

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from crtsh_certificate where query = 'example.com';
+-------------+-----------------------------------------------------------------------------------------------------------------------------------+---------------------------+---------------------------+------------------------------------------------------------------>
| id          | dns_names                                                                                                                         | not_before                | not_after                 | subject                                                          >
+-------------+-----------------------------------------------------------------------------------------------------------------------------------+---------------------------+---------------------------+------------------------------------------------------------------>
| 24560621    | ["*.example.com","m.example.com","www.example.com","example.com"]                                                                 | 2016-07-14T05:30:00+05:30 | 2017-07-15T05:29:59+05:30 | {"CommonName":"www.example.com","Country":["KR"],"ExtraNames":nul>
|             |                                                                                                                                   |                           |                           |                                                                  >
|             |                                                                                                                                   |                           |                           |                                                                  >
|             |                                                                                                                                   |                           |                           |                                                                  >
|             |                                                                                                                                   |                           |                           |                                                                  >
|             |                                                                                                                                   |                           |                           |                                                                  >
|             |                                                                                                                                   |                           |                           |                                                                  >
|             |                                                                                                                                   |                           |                           |                                                                  >
|             |                                                                                                                                   |                           |                           |                                                                  >
|             |                                                                                                                                   |                           |                           |                                                                  >
| 24558997    | ["dev.example.com","products.example.com","support.example.com","www.example.com","example.com"]                                  | 2016-07-14T05:30:00+05:30 | 2018-07-15T05:29:59+05:30 | {"CommonName":"www.example.com","Country":["KR"],"ExtraNames":nul>
|             |                                                                                                                                   |                           |                           |                                                                  >
|             |                                                                                                                                   |                           |                           |                                                                  >
|             |                                                                                                                                   |                           |                           |                                                                  >

```
</details>
